### PR TITLE
Renames the bypass-client-id and bypass-client-secret options

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ Prerequisites:
 # NOTE: one may optionally add the following, else it defaults to gitlab.com:
 # api-scheme=http gitlab-host=10.107.2.9 gitlab-port 443
 juju config finos-legend-gitlab-integrator-k8s \
-    bypass-client-id=<cliend id> \
-    bypass-client-secret=<client secret>
+    gitlab-client-id=<cliend id> \
+    gitlab-client-secret=<client secret>
 ```
 
 #### Fetching the redirect URIs:
@@ -117,7 +117,7 @@ if creating an application on the spot.
 In this sense, reusing GitLab applications upon redeploying the integrator will
 require taking one of the following options:
 1. *reusing an existing GitLab application* can be achieved by reconfiguring the
-   charm using the `bypass-client-id` and `bypass-client-secret` configuration
+   charm using the `gitlab-client-id` and `gitlab-client-secret` configuration
    options with the client ID/secret which can be obtained from
    the GitLab Web user interface as described in section .B above.
 2. manually deleting the application and having the integrator create a new one on the next run

--- a/config.yaml
+++ b/config.yaml
@@ -29,23 +29,23 @@ options:
     description: |
       String access token for the GitLab API on the provided host.
 
-  bypass-client-id:
+  gitlab-client-id:
     type: string
     default: ""
     description: |
       Client ID for a pre-created application already present on GitLab.
-      If provided alongside 'bypass-client-secret', the integrator will skip
+      If provided alongside 'gitlab-client-secret', the integrator will skip
       creating the application on GitLab and simply provide these application
       credentials to all the Legend components.
       Note that one must still manually update the GitLab application with the
       redirect URIs returned by the 'get-redirect-uris' action.
 
-  bypass-client-secret:
+  gitlab-client-secret:
     type: string
     default: ""
     description: |
       Client secret for a pre-created application already present on GitLab.
-      If provided alongside 'bypass-client-id', the integrator will skip
+      If provided alongside 'gitlab-client-id', the integrator will skip
       creating the application on GitLab and simply provide these application
       credentials to all the Legend components.
       Note that one must still manually update the GitLab application with the

--- a/src/charm.py
+++ b/src/charm.py
@@ -172,17 +172,17 @@ class LegendGitlabIntegratorCharm(charm.CharmBase):
     def _check_set_up_gitlab_application(self):
         """Sets up the GitLab application for the Legend deployment.
 
-        If a GitLab App bypass ID/secret was provided, this method will simply use those.
+        If a GitLab App ID/secret was provided, this method will simply use those.
         Else, it will attempt to create a new application on GitLab.
         Either way, the client ID/secret of the app is set within stored state as it is only
         made available by the API on app creation.
         """
-        bypass_client_id = self.model.config["bypass-client-id"]
-        bypass_client_secret = self.model.config["bypass-client-secret"]
-        if all([bypass_client_id, bypass_client_secret]):
+        gitlab_client_id = self.model.config["gitlab-client-id"]
+        gitlab_client_secret = self.model.config["gitlab-client-secret"]
+        if all([gitlab_client_id, gitlab_client_secret]):
             logger.info("Using pre-seeded Gitlab application ID/settings.")
-            self._stored.gitlab_client_id = bypass_client_id
-            self._stored.gitlab_client_secret = bypass_client_secret
+            self._stored.gitlab_client_id = gitlab_client_id
+            self._stored.gitlab_client_secret = gitlab_client_secret
             return None
 
         # Check GitLab client available:

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -59,8 +59,8 @@ class TestCharm(unittest.TestCase):
             "gitlab_host": config["gitlab-host"],
             "gitlab_port": config["gitlab-port"],
             "gitlab_scheme": config["api-scheme"],
-            "client_id": config.get("bypass-client-id", client_id),
-            "client_secret": config.get("bypass-client-secret", client_secret),
+            "client_id": config.get("gitlab-client-id", client_id),
+            "client_secret": config.get("gitlab-client-secret", client_secret),
             "openid_discovery_url": (
                 charm.GITLAB_OPENID_DISCOVERY_URL_FORMAT
                 % {
@@ -81,7 +81,7 @@ class TestCharm(unittest.TestCase):
     @mock.patch(
         "charms.finos_legend_gitlab_integrator_k8s.v0.legend_gitlab.set_legend_gitlab_creds_in_relation_data"
     )
-    def test_charm_setup_gitlab_bypass(self, _set_legend_creds_mock, _mock_ssl):
+    def test_charm_setup_gitlab_by_id_and_secret(self, _set_legend_creds_mock, _mock_ssl):
         _mock_ssl.get_server_certificate.return_value = b"test_cert_pem"
         _mock_ssl.PEM_cert_to_DER_cert.return_value = b"test_cert_der"
 
@@ -97,21 +97,21 @@ class TestCharm(unittest.TestCase):
             "awaiting gitlab server configuration or relation",
         )
 
-        # Give it bypass creds for GitLab:
+        # Give it the direct client ID and secret creds for GitLab:
         config_values = {
             "gitlab-host": "gitlab_host",
             "api-scheme": "https",
             "gitlab-port": 1234,
-            "bypass-client-id": "test_client_id",
-            "bypass-client-secret": "test_client_secret",
+            "gitlab-client-id": "test_client_id",
+            "gitlab-client-secret": "test_client_secret",
         }
         self.harness.update_config(config_values)
         self.assertIsInstance(self.harness.charm.unit.status, model.ActiveStatus)
         self.assertEqual(
-            self.harness.charm._stored.gitlab_client_id, config_values["bypass-client-id"]
+            self.harness.charm._stored.gitlab_client_id, config_values["gitlab-client-id"]
         )
         self.assertEqual(
-            self.harness.charm._stored.gitlab_client_secret, config_values["bypass-client-secret"]
+            self.harness.charm._stored.gitlab_client_secret, config_values["gitlab-client-secret"]
         )
 
         # Check relations data:
@@ -360,16 +360,16 @@ class TestCharm(unittest.TestCase):
             "gitlab-host": "gitlab_host",
             "api-scheme": "https",
             "gitlab-port": 1234,
-            "bypass-client-id": "test_client_id",
-            "bypass-client-secret": "test_client_secret",
+            "gitlab-client-id": "test_client_id",
+            "gitlab-client-secret": "test_client_secret",
         }
         self.harness.update_config(config_values)
         self.assertIsInstance(self.harness.charm.unit.status, model.ActiveStatus)
         self.assertEqual(
-            self.harness.charm._stored.gitlab_client_id, config_values["bypass-client-id"]
+            self.harness.charm._stored.gitlab_client_id, config_values["gitlab-client-id"]
         )
         self.assertEqual(
-            self.harness.charm._stored.gitlab_client_secret, config_values["bypass-client-secret"]
+            self.harness.charm._stored.gitlab_client_secret, config_values["gitlab-client-secret"]
         )
 
         expected_creds = self._get_gitlab_creds_from_config(


### PR DESCRIPTION
Those config options were being used to simply connect to Gitlab directly, it wasn't bypassing anything.

This will rename those config options to something that doesn't include the keyword 'bypass'.