### PR TITLE
Fixes gitlab.com SSL certificate fetching issue

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -4,15 +4,15 @@
 
 """Module defining a Charm providing GitLab integration for FINOS Legend."""
 
-import base64
 import functools
 import logging
-import ssl
 import traceback
 
 import gitlab
 from charms.finos_legend_gitlab_integrator_k8s.v0 import legend_gitlab
 from ops import charm, framework, main, model
+
+import utils
 
 logger = logging.getLogger(__name__)
 
@@ -298,17 +298,13 @@ class LegendGitlabIntegratorCharm(charm.CharmBase):
                 "both a 'gitlab-host' and 'gitlab-port' config options are required"
             )
 
-        cert = None
         try:
-            cert = ssl.get_server_certificate((host, port))
+            return utils.get_gitlab_host_cert_b64(host, port)
         except Exception:
             return model.BlockedStatus(
                 "failed to retrieve SSL cert for GitLab host '%s:%d'. SSL is required "
                 "for the GitLab to be usable by the Legend components" % (host, port)
             )
-
-        # NOTE(aznashwan): we can also send the .PEM but there's no point in base64-ing it twice:
-        return base64.b64encode(ssl.PEM_cert_to_DER_cert(cert)).decode()
 
     def _get_gitlab_relation_data(self):
         if not all([self._stored.gitlab_client_id, self._stored.gitlab_client_secret]):

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,0 +1,70 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Module containing various utils used by the GitLab Integration Charm."""
+
+import base64
+import logging
+import ssl
+
+import requests
+
+# inspired by: https://stackoverflow.com/questions/16903528/how-to-get-response-ssl-certificate-from-requests-in-python  # noqa
+HTTPResponse = requests.packages.urllib3.response.HTTPResponse
+_HTTPResponse__init__ = HTTPResponse.__init__
+
+HTTPAdapter = requests.adapters.HTTPAdapter
+_build_response = HTTPAdapter.build_response
+
+
+def _new_httpresponse__init__(self, *args, **kwargs):
+    _HTTPResponse__init__(self, *args, **kwargs)
+
+    # NOTE(claudiub): The ssl library returns a PEM certificate, but we're
+    # converting it to DER in the end.
+    self.peer_cert = None
+    try:
+        self.peer_cert = self.connection.sock.getpeercert(True)
+    except AttributeError:
+        pass
+
+
+def _new_build_response(self, request, resp):
+    response = _build_response(self, request, resp)
+    try:
+        response.peer_cert = resp.peer_cert
+    except AttributeError:
+        pass
+    return response
+
+
+HTTPResponse.__init__ = _new_httpresponse__init__
+HTTPAdapter.build_response = _new_build_response
+
+
+def get_gitlab_host_cert_b64(host, port):
+    """Returns the server certificate from the given host and port."""
+    try:
+        # NOTE(aznashwan): we can also send the .PEM but there's no point in base64-ing it twice:
+        cert = ssl.get_server_certificate((host, port))
+        return base64.b64encode(ssl.PEM_cert_to_DER_cert(cert)).decode()
+    except Exception as ex:
+        logging.warning(
+            "Encountered exception while getting the '%s:%s' SSL certificate. "
+            "Using alternate method. Exception: %s",
+            host,
+            port,
+            ex,
+        )
+
+    # NOTE(claudiub): Since we're not logged in, accessing gitlab.com will
+    # redirect us to about.gitlab.com, which means that we won't actually get
+    # gitlab.com's SSL certificate. For this, we're using gitlab.com/explore
+    # instead, which has no redirects.
+    # TODO(claudiub): Find a cleaner approach.
+    url = "https://%s:%s/explore" % (host, port)
+    response = requests.get(url)
+    if not response.peer_cert:
+        msg = "Could not fetch the SSL certificate from %s:%s" % (host, port)
+        raise Exception(msg)
+    return base64.b64encode(response.peer_cert).decode()

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -77,7 +77,7 @@ class TestCharm(unittest.TestCase):
             creds["gitlab_host_cert_b64"] = base64.b64encode(cert).decode()
         return creds
 
-    @mock.patch("charm.ssl")
+    @mock.patch.object(charm.utils, "ssl")
     @mock.patch(
         "charms.finos_legend_gitlab_integrator_k8s.v0.legend_gitlab.set_legend_gitlab_creds_in_relation_data"
     )
@@ -123,7 +123,7 @@ class TestCharm(unittest.TestCase):
             relations_set_calls.append(mock.call({}, creds, validate_creds=False))
         _set_legend_creds_mock.assert_has_calls(relations_set_calls)
 
-    @mock.patch("charm.ssl")
+    @mock.patch.object(charm.utils, "ssl")
     @mock.patch("gitlab.Gitlab")
     @mock.patch(
         "charms.finos_legend_gitlab_integrator_k8s.v0.legend_gitlab.set_legend_gitlab_creds_in_relation_data"
@@ -335,7 +335,7 @@ class TestCharm(unittest.TestCase):
         self.harness.charm._on_get_redirect_uris_action(event)
         event.set_results.assert_called_once_with({"result": expected})
 
-    @mock.patch("charm.ssl")
+    @mock.patch.object(charm.utils, "ssl")
     @mock.patch(
         "charms.finos_legend_gitlab_integrator_k8s.v0.legend_gitlab.set_legend_gitlab_creds_in_relation_data"
     )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,96 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import base64
+import unittest
+from unittest import mock
+
+import utils
+
+
+class TestUtils(unittest.TestCase):
+    @mock.patch.object(utils, "_HTTPResponse__init__")
+    def test_httpresponse_init(self, mock_orig_constructor):
+        mock_self = mock.Mock()
+        mock_sock = mock_self.connection.sock
+        fake_cert = "fake-cert"
+        mock_sock.getpeercert.return_value = fake_cert
+
+        utils._new_httpresponse__init__(mock_self, mock.sentinel.arg, key=mock.sentinel.kwarg)
+
+        self.assertEqual(fake_cert, mock_self.peer_cert)
+        mock_orig_constructor.assert_called_once_with(
+            mock_self, mock.sentinel.arg, key=mock.sentinel.kwarg
+        )
+        mock_sock.getpeercert.assert_called_once_with(True)
+
+    @mock.patch.object(utils, "_HTTPResponse__init__")
+    def test_httpresponse_init_err(self, mock_original_httpresponse_init):
+        mock_self = mock.Mock()
+        mock_sock = mock_self.connection.sock
+        mock_sock.getpeercert.side_effect = AttributeError
+
+        utils._new_httpresponse__init__(mock_self, mock.sentinel.arg, key=mock.sentinel.kwarg)
+
+        self.assertIsNone(mock_self.peer_cert)
+        mock_sock.getpeercert.assert_called_once_with(True)
+
+    @mock.patch.object(utils, "_build_response")
+    def test_new_build_response(self, mock_original_build):
+        mock_resp = mock.Mock()
+
+        response = utils._new_build_response(mock.sentinel.self, mock.sentinel.request, mock_resp)
+
+        self.assertEqual(mock_resp.peer_cert, response.peer_cert)
+        mock_original_build.assert_called_once_with(
+            mock.sentinel.self, mock.sentinel.request, mock_resp
+        )
+
+    @mock.patch.object(utils, "_build_response")
+    def test_new_build_response_err(self, mock_original_build):
+        mock_resp = mock.Mock(spec=[])
+        mock_original_build.return_value.peer_cert = None
+
+        response = utils._new_build_response(mock.sentinel.self, mock.sentinel.request, mock_resp)
+
+        self.assertIsNone(response.peer_cert)
+        mock_original_build.assert_called_once_with(
+            mock.sentinel.self, mock.sentinel.request, mock_resp
+        )
+
+    @mock.patch("ssl.PEM_cert_to_DER_cert")
+    @mock.patch("ssl.get_server_certificate")
+    def test_get_gitlab_host_cert(self, mock_get_cert, mock_pem_to_der):
+        cert = b"some_cert"
+        mock_pem_to_der.return_value = cert
+
+        result = utils.get_gitlab_host_cert_b64(mock.sentinel.host, mock.sentinel.port)
+
+        self.assertEqual(base64.b64encode(cert).decode(), result)
+        mock_get_cert.assert_called_once_with((mock.sentinel.host, mock.sentinel.port))
+        mock_pem_to_der.assert_called_once_with(mock_get_cert.return_value)
+
+    @mock.patch("requests.get")
+    @mock.patch("ssl.get_server_certificate")
+    def test_get_gitlab_host_cert_gitlab(self, mock_get_cert, mock_get):
+        mock_get_cert.side_effect = Exception("Just as expected.")
+        cert = b"some_cert"
+        mock_get.return_value.peer_cert = cert
+        gitlab_name = "gitlab.com"
+
+        result = utils.get_gitlab_host_cert_b64(gitlab_name, 443)
+
+        self.assertEqual(base64.b64encode(cert).decode(), result)
+        expected_url = "https://%s:%s/explore" % (gitlab_name, 443)
+        mock_get.assert_called_once_with(expected_url)
+
+    @mock.patch("requests.get")
+    @mock.patch("ssl.get_server_certificate")
+    def test_get_gitlab_host_cert_gitlab_err(self, mock_get_cert, mock_get):
+        mock_get_cert.side_effect = Exception("Just as expected.")
+        mock_get.return_value.peer_cert = None
+        gitlab_name = "gitlab.com"
+
+        self.assertRaises(Exception, utils.get_gitlab_host_cert_b64, gitlab_name, 443)
+        expected_url = "https://%s:%s/explore" % (gitlab_name, 443)
+        mock_get.assert_called_once_with(expected_url)


### PR DESCRIPTION
There are a few issues with getting the SSL certificate from gitlab.com through ``ssl.get_server_certificate()``.

First of all, ssl.get_server_certificate() will end up with an ``OSError: [Errno 0] Error`` error, which will cause the Charm to end up
in a ``BlockedState``. This issue is mentioned here [1], and a fix for it has been included in Python 3.8.6. The GitLab Integrator Charm is using Python 3.8.5.

Secondly, even in a newer Python, this error is encountered instead:

```
ssl.SSLError: [SSL: SSLV3_ALERT_HANDSHAKE_FAILURE] sslv3 alert handshake failure (_ssl.c:1131)
```

Alternatively, we can use requests.get to get the SSL certificate. However, the connection and details regarding it will get cleaned up after the request finishes, so we need to fetch the certificate beforehand. Inspired by [2].

However, since we're not logged in, accessing ``gitlab.com`` will redirect us to ``about.gitlab.com``, which means that we won't actually get ``gitlab.com``'s SSL certificate. For this, we can use ``gitlab.com/explore``, which has no redirects.

Fixes: https://github.com/finos/legend-integration-juju/issues/7

[1] https://bugs.python.org/issue31122
[2] https://stackoverflow.com/questions/16903528/how-to-get-response-ssl-certificate-from-requests-in-python