### PR TITLE
Fixes ModelError on invalid relation data

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -244,6 +244,11 @@ class LegendGitlabIntegratorCharm(charm.CharmBase):
         except model.TooManyRelatedAppsError:
             logger.error("this operator does not support multiple %s relations" % (relation_name))
             return None
+        except model.ModelError as ex:
+            logger.error(
+                "Encountered an error while getting the '%s' redirect URIs: %s", relation_name, ex
+            )
+            return None
 
     def _get_legend_services_redirect_uris(self):
         """Returns a string containing the service URLs in the correct order.


### PR DESCRIPTION
Trying to access the relation data on an invalid application might end up with an uncaught ModelError (``b'ERROR "" is not a valid unit or application\n'``).

Catching the error will prevent it entering an error state.

