### PR TITLE
WIP: Adds gitlab charm integration

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -8,13 +8,12 @@ description: |
 summary: |
   Charm which interfaces with GitLab to provide access for FINOS Legend components.
 
-# requires:
-# TODO(aznashwan): add optional relation to GitLab charm here
-# gitlab:
-#   interface: gitlab?
-#   limit: 1
-#   optional: false
-#   scope: global
+requires:
+  gitlab:
+    interface: gitlab
+    limit: 1
+    optional: true
+    scope: global
 
 provides:
   legend-sdlc-gitlab:


### PR DESCRIPTION
Adds the gitlab relation. In the relation data we will receive the credentials necessary to connect to a charmed gitlab instance: host, port, api-scheme, access-token. These can be used to initialize a gitlab client with which we can create GitLab applications.

Currently, you cannot update existing GitLab applications through the current /applications API, which means that we won't be able to update the Callback URIs for the gitlab applications we create (for example, if the Legend application's ``service-hostname`` changes, we would normally have to update the Callback URIs).

Ref: https://gitlab.com/gitlab-org/gitlab/-/issues/359065

Fixes: https://github.com/finos/legend-juju-gitlab-integrator/issues/10