### PR TITLE
Update docs with increased TTL charmcraft creds.

### DIFF
--- a/docs/CharmPublishing.md
+++ b/docs/CharmPublishing.md
@@ -5,7 +5,7 @@ After a Pull Request merged, the ``Publish Charm`` [Github action](../.github/wo
 ```bash
 charmcraft login --export=secrets-gitlab-int.auth --charm=finos-legend-gitlab-integrator-k8s \
       --permission=package-manage --permission=package-view-revisions \
-      --channel=edge --ttl=1576800
+      --channel=edge --ttl=15780000
 ```
 
 This token will have to be updated periodically since it has a certain time to live set.


### PR DESCRIPTION
Update the documentation with an increased time-to-live for the
charmcraft login credentials. The new TTL is 6 months replacing the old
value of 18 days. This attenuates certificate expiration issues.