### PR TITLE
Fixes unit tests

### DIFF
--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -360,7 +360,7 @@ class TestCharm(unittest.TestCase):
 
         # Add the relations to the charm, and get the redirect URIs from it. It should return
         # None, and not raise an exception.
-        self._add_relation(charm.RELATION_NAME_SDLC, {})
+        self._add_relation(charm.RELATION_NAME_SDLC, {"foo": "lish"})
         mock_get_redirect_uris = self._patch(
             charm.legend_gitlab.LegendGitlabConsumer, "get_legend_redirect_uris"
         )


### PR DESCRIPTION
If the relation is broken, accessing relation.data results in a ``RuntimeError``.

We should avoid creating the ``LegendGitlabConsumer`` in this case, otherwise we can end up with 2 objects claiming the same object path, resulting in an error when the relation is rejoined.